### PR TITLE
Changed spying on engine.model.Document#enqueueChanges

### DIFF
--- a/tests/entercommand.js
+++ b/tests/entercommand.js
@@ -32,9 +32,9 @@ beforeEach( () => {
 
 describe( 'EnterCommand', () => {
 	it( 'enters a block using enqueueChanges', () => {
-		const spy = sinon.spy( doc, 'enqueueChanges' );
-
 		setData( doc, '<p>foo<selection /></p>' );
+
+		const spy = sinon.spy( doc, 'enqueueChanges' );
 
 		editor.execute( 'enter' );
 


### PR DESCRIPTION
Fixes ckeditor/ckeditor5#4550.
Model utils method `setData` uses `enqueueChanges` internally so spying should be started after it.
