### PR TITLE
Create `InsertDelta` instead of `SplitDelta` if split is at the beginning of block.

### DIFF
--- a/src/entercommand.js
+++ b/src/entercommand.js
@@ -82,14 +82,19 @@ function enterBlock( dataController, batch, selection, schema ) {
 }
 
 function splitBlock( batch, selection, splitPos ) {
+	const oldElement = splitPos.parent;
+	const newElement = new oldElement.constructor( oldElement.name, oldElement.getAttributes() );
+
 	if ( splitPos.isAtEnd ) {
 		// If the split is at the end of element, instead of splitting, just create a clone of position's parent
-		// element and insert it after cloned element. The result is the same but less operations are taken
+		// element and insert it after split element. The result is the same but less operations are done
 		// and it's more semantically correct (when it comes to operational transformation).
-		const oldElement = splitPos.parent;
-		const newElement = new oldElement.constructor( oldElement.name, oldElement.getAttributes() );
-
 		batch.insert( Position.createAfter( splitPos.parent ), newElement );
+	} else if ( splitPos.isAtStart ) {
+		// If the split is at the start of element, instead of splitting, just create a clone of position's parent
+		// element and insert it before split element. The result is the same but less operations are done
+		// and it's more semantically correct (when it comes to operational transformation).
+		batch.insert( Position.createBefore( splitPos.parent ), newElement );
 	} else {
 		batch.split( splitPos );
 	}

--- a/tests/entercommand.js
+++ b/tests/entercommand.js
@@ -5,6 +5,7 @@
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import EnterCommand from '../src/entercommand';
+import InsertDelta from '@ckeditor/ckeditor5-engine/src/model/delta/insertdelta';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'EnterCommand', () => {
@@ -54,6 +55,26 @@ describe( 'EnterCommand', () => {
 
 			// After all enqueued changes are done, the command execution is reflected.
 			expect( getData( doc, { withoutSelection: true } ) ).to.equal( '<p>foo</p><p></p>' );
+		} );
+
+		it( 'creates InsertDelta if enter is at the beginning of block', () => {
+			setData( doc, '<p>[]foo</p>' );
+
+			editor.execute( 'enter' );
+
+			const deltas = Array.from( doc.history.getDeltas() );
+
+			expect( deltas[ deltas.length - 1 ] ).to.be.instanceof( InsertDelta );
+		} );
+
+		it( 'creates InsertDelta if enter is at the end of block', () => {
+			setData( doc, '<p>foo[]</p>' );
+
+			editor.execute( 'enter' );
+
+			const deltas = Array.from( doc.history.getDeltas() );
+
+			expect( deltas[ deltas.length - 1 ] ).to.be.instanceof( InsertDelta );
 		} );
 	} );
 


### PR DESCRIPTION
Internal: Create `InsertDelta` instead of `SplitDelta` if split is at the beginning of block.. Closes ckeditor/ckeditor5#4565.