### PR TITLE
EnterObserver stops keydown event if enter event is stopped.

### DIFF
--- a/src/enterobserver.js
+++ b/src/enterobserver.js
@@ -22,7 +22,17 @@ export default class EnterObserver extends Observer {
 
 		document.on( 'keydown', ( evt, data ) => {
 			if ( this.isEnabled && data.keyCode == keyCodes.enter ) {
+				// Save the event object to check later if it was stopped or not.
+				let event;
+				document.once( 'enter', evt => ( event = evt ), { priority: 'highest' } );
+
 				document.fire( 'enter', new DomEventData( document, data.domEvent ) );
+
+				// Stop `keydown` event if `enter` event was stopped.
+				// https://github.com/ckeditor/ckeditor5/issues/753
+				if ( event && event.stop.called ) {
+					evt.stop();
+				}
 			}
 		} );
 	}

--- a/tests/enterobserver.js
+++ b/tests/enterobserver.js
@@ -49,6 +49,30 @@ describe( 'EnterObserver', () => {
 
 			expect( spy.calledOnce ).to.be.false;
 		} );
+
+		it( 'should stop keydown event when enter event is stopped', () => {
+			const keydownSpy = sinon.spy();
+			viewDocument.on( 'keydown', keydownSpy );
+			viewDocument.on( 'enter', evt => evt.stop() );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'enter' )
+			} ) );
+
+			sinon.assert.notCalled( keydownSpy );
+		} );
+
+		it( 'should not stop keydown event when enter event is not stopped', () => {
+			const keydownSpy = sinon.spy();
+			viewDocument.on( 'keydown', keydownSpy );
+			viewDocument.on( 'enter', evt => evt.stop() );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'x' )
+			} ) );
+
+			sinon.assert.calledOnce( keydownSpy );
+		} );
 	} );
 
 	function getDomEvent() {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `EnterObserver` stops `keydown` event when `enter` event is stopped. Closes: https://github.com/ckeditor/ckeditor5/issues/753.

---
Please close together with: https://github.com/ckeditor/ckeditor5-typing/pull/133.
  