### PR TITLE
Default action of Enter and ShiftEnter should be always prevented

### DIFF
--- a/src/enter.js
+++ b/src/enter.js
@@ -36,13 +36,14 @@ export default class Enter extends Plugin {
 		editor.commands.add( 'enter', new EnterCommand( editor ) );
 
 		this.listenTo( viewDocument, 'enter', ( evt, data ) => {
+			data.preventDefault();
+
 			// The soft enter key is handled by the ShiftEnter plugin.
 			if ( data.isSoft ) {
 				return;
 			}
 
 			editor.execute( 'enter' );
-			data.preventDefault();
 			view.scrollToTheSelection();
 		}, { priority: 'low' } );
 	}

--- a/src/shiftenter.js
+++ b/src/shiftenter.js
@@ -58,13 +58,14 @@ export default class ShiftEnter extends Plugin {
 		editor.commands.add( 'shiftEnter', new ShiftEnterCommand( editor ) );
 
 		this.listenTo( viewDocument, 'enter', ( evt, data ) => {
+			data.preventDefault();
+
 			// The hard enter key is handled by the Enter plugin.
 			if ( !data.isSoft ) {
 				return;
 			}
 
 			editor.execute( 'shiftEnter' );
-			data.preventDefault();
 			view.scrollToTheSelection();
 		}, { priority: 'low' } );
 	}

--- a/tests/enter.js
+++ b/tests/enter.js
@@ -53,7 +53,7 @@ describe( 'Enter feature', () => {
 		viewDocument.fire( 'enter', new DomEventData( viewDocument, domEvt ) );
 
 		sinon.assert.calledOnce( scrollSpy );
-		sinon.assert.callOrder( executeSpy, scrollSpy );
+		sinon.assert.callOrder( domEvt.preventDefault, executeSpy, scrollSpy );
 	} );
 
 	it( 'does not execute the command if soft enter should be used', () => {
@@ -63,6 +63,14 @@ describe( 'Enter feature', () => {
 		viewDocument.fire( 'enter', new DomEventData( viewDocument, domEvt, { isSoft: true } ) );
 
 		sinon.assert.notCalled( commandExecuteSpy );
+	} );
+
+	it( 'prevents default event action even if the command should not be executed', () => {
+		const domEvt = getDomEvent();
+
+		viewDocument.fire( 'enter', new DomEventData( viewDocument, domEvt, { isSoft: true } ) );
+
+		sinon.assert.calledOnce( domEvt.preventDefault );
 	} );
 
 	function getDomEvent() {

--- a/tests/shiftenter.js
+++ b/tests/shiftenter.js
@@ -53,7 +53,7 @@ describe( 'ShiftEnter feature', () => {
 		viewDocument.fire( 'enter', new DomEventData( viewDocument, domEvt, { isSoft: true } ) );
 
 		sinon.assert.calledOnce( scrollSpy );
-		sinon.assert.callOrder( executeSpy, scrollSpy );
+		sinon.assert.callOrder( domEvt.preventDefault, executeSpy, scrollSpy );
 	} );
 
 	it( 'does not execute the command if hard enter should be used', () => {
@@ -63,6 +63,14 @@ describe( 'ShiftEnter feature', () => {
 		viewDocument.fire( 'enter', new DomEventData( viewDocument, domEvt, { isSoft: false } ) );
 
 		sinon.assert.notCalled( commandExecuteSpy );
+	} );
+
+	it( 'prevents default event action even if the command should not be executed', () => {
+		const domEvt = getDomEvent();
+
+		viewDocument.fire( 'enter', new DomEventData( viewDocument, domEvt, { isSoft: false } ) );
+
+		sinon.assert.calledOnce( domEvt.preventDefault );
 	} );
 
 	function getDomEvent() {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Default action of `Enter` event should be always prevented. Closes ckeditor/ckeditor5#1120.
