### PR TITLE
Enter command will use writer.split() also at the beginning and at the end of a block

### DIFF
--- a/src/entercommand.js
+++ b/src/entercommand.js
@@ -56,7 +56,7 @@ function enterBlock( model, writer, selection, schema ) {
 	}
 
 	if ( isSelectionEmpty ) {
-		splitBlock( writer, selection, range.start );
+		splitBlock( writer, range.start );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );
 		const isContainedWithinOneElement = ( startElement == endElement );
@@ -68,7 +68,7 @@ function enterBlock( model, writer, selection, schema ) {
 			//
 			// <h>x[xx]x</h>		-> <h>x^x</h>			-> <h>x</h><h>^x</h>
 			if ( isContainedWithinOneElement ) {
-				splitBlock( writer, selection, selection.focus );
+				splitBlock( writer, selection.focus );
 			}
 			// Selection over multiple elements.
 			//
@@ -80,23 +80,7 @@ function enterBlock( model, writer, selection, schema ) {
 	}
 }
 
-function splitBlock( writer, selection, splitPos ) {
-	const oldElement = splitPos.parent;
-	const newElement = new oldElement.constructor( oldElement.name, oldElement.getAttributes() );
-
-	if ( splitPos.isAtEnd ) {
-		// If the split is at the end of element, instead of splitting, just create a clone of position's parent
-		// element and insert it after split element. The result is the same but less operations are done
-		// and it's more semantically correct (when it comes to operational transformation).
-		writer.insert( newElement, splitPos.parent, 'after' );
-	} else if ( splitPos.isAtStart ) {
-		// If the split is at the start of element, instead of splitting, just create a clone of position's parent
-		// element and insert it before split element. The result is the same but less operations are done
-		// and it's more semantically correct (when it comes to operational transformation).
-		writer.insert( newElement, splitPos.parent, 'before' );
-	} else {
-		writer.split( splitPos );
-	}
-
+function splitBlock( writer, splitPos ) {
+	writer.split( splitPos );
 	writer.setSelection( splitPos.parent.nextSibling, 0 );
 }

--- a/tests/entercommand.js
+++ b/tests/entercommand.js
@@ -5,7 +5,6 @@
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import EnterCommand from '../src/entercommand';
-import InsertOperation from '@ckeditor/ckeditor5-engine/src/model/operation/insertoperation';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'EnterCommand', () => {
@@ -46,7 +45,7 @@ describe( 'EnterCommand', () => {
 	} );
 
 	describe( 'EnterCommand', () => {
-		it( 'enters a block using parent batch', () => {
+		it( 'splits a block using parent batch', () => {
 			setData( model, '<p>foo[]</p>' );
 
 			model.change( writer => {
@@ -54,26 +53,6 @@ describe( 'EnterCommand', () => {
 				editor.execute( 'enter' );
 				expect( writer.batch.operations ).to.length.above( 0 );
 			} );
-		} );
-
-		it( 'creates InsertOperation if enter is at the beginning of block', () => {
-			setData( model, '<p>[]foo</p>' );
-
-			editor.execute( 'enter' );
-
-			const ops = doc.history.getOperations();
-
-			expect( ops[ ops.length - 1 ] ).to.be.instanceof( InsertOperation );
-		} );
-
-		it( 'creates InsertOperation if enter is at the end of block', () => {
-			setData( model, '<p>foo[]</p>' );
-
-			editor.execute( 'enter' );
-
-			const operations = Array.from( doc.history.getOperations() );
-
-			expect( operations[ operations.length - 1 ] ).to.be.instanceof( InsertOperation );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Enter command will use `writer.split()` also at the beginning and at the end of a block.

---

### Additional information

Current solution is to use `writer.insert()` (`InsertOperation`) when the split takes places at the beginning or at the end of the element. However, this leads to problems in collaboration. If Client A uses enter at the end of an element and then Client B writes something there and then Client A uses undo, content written by Client B is gone. In the current solution, content written by Client B will be moved to the previous element. This is a more natural behavior and it does not lead to content loss.