### PR TITLE
Add support for preserving text attributes on enter

### DIFF
--- a/src/entercommand.js
+++ b/src/entercommand.js
@@ -56,7 +56,10 @@ function enterBlock( model, writer, selection, schema ) {
 	}
 
 	if ( isSelectionEmpty ) {
+		// List of text attributes copied to new line/block.
+		const filteredAttr = getAllowedAttributes( writer.model.schema, selection.getAttributes() );
 		splitBlock( writer, range.start );
+		writer.setSelectionAttribute( filteredAttr );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );
 		const isContainedWithinOneElement = ( startElement == endElement );
@@ -83,4 +86,12 @@ function enterBlock( model, writer, selection, schema ) {
 function splitBlock( writer, splitPos ) {
 	writer.split( splitPos );
 	writer.setSelection( splitPos.parent.nextSibling, 0 );
+}
+
+function* getAllowedAttributes( schema, allAttributes ) {
+	for ( const attr of allAttributes ) {
+		if ( attr && schema.getAttributeProperties( attr[ 0 ] ).copyOnEnter ) {
+			yield attr;
+		}
+	}
 }

--- a/src/entercommand.js
+++ b/src/entercommand.js
@@ -56,10 +56,9 @@ function enterBlock( model, writer, selection, schema ) {
 	}
 
 	if ( isSelectionEmpty ) {
-		// List of text attributes copied to new line/block.
-		const filteredAttr = getAllowedAttributes( writer.model.schema, selection.getAttributes() );
+		const attributesToCopy = getCopyOnEnterAttributes( writer.model.schema, selection.getAttributes() );
 		splitBlock( writer, range.start );
-		writer.setSelectionAttribute( filteredAttr );
+		writer.setSelectionAttribute( attributesToCopy );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );
 		const isContainedWithinOneElement = ( startElement == endElement );
@@ -88,10 +87,10 @@ function splitBlock( writer, splitPos ) {
 	writer.setSelection( splitPos.parent.nextSibling, 0 );
 }
 
-function* getAllowedAttributes( schema, allAttributes ) {
-	for ( const attr of allAttributes ) {
-		if ( attr && schema.getAttributeProperties( attr[ 0 ] ).copyOnEnter ) {
-			yield attr;
+function* getCopyOnEnterAttributes( schema, allAttributes ) {
+	for ( const attribute of allAttributes ) {
+		if ( attribute && schema.getAttributeProperties( attribute[ 0 ] ).copyOnEnter ) {
+			yield attribute;
 		}
 	}
 }

--- a/src/entercommand.js
+++ b/src/entercommand.js
@@ -8,6 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
+import { getCopyOnEnterAttributes } from './utils';
 
 /**
  * Enter command. It is used by the {@link module:enter/enter~Enter Enter feature} to handle the <kbd>Enter</kbd> key.
@@ -85,12 +86,4 @@ function enterBlock( model, writer, selection, schema ) {
 function splitBlock( writer, splitPos ) {
 	writer.split( splitPos );
 	writer.setSelection( splitPos.parent.nextSibling, 0 );
-}
-
-function* getCopyOnEnterAttributes( schema, allAttributes ) {
-	for ( const attribute of allAttributes ) {
-		if ( attribute && schema.getAttributeProperties( attribute[ 0 ] ).copyOnEnter ) {
-			yield attribute;
-		}
-	}
 }

--- a/src/shiftentercommand.js
+++ b/src/shiftentercommand.js
@@ -85,7 +85,7 @@ function softBreakAction( model, writer, selection ) {
 		const attributesToCopy = getCopyOnEnterAttributes( model.schema, selection.getAttributes() );
 		insertBreak( writer, range.end );
 
-		writer.removeSelectionAttribute( Array.from( selection.getAttributes() ).map( x => x[ 0 ] ) );
+		writer.removeSelectionAttribute( Array.from( selection.getAttributeKeys() ) );
 		writer.setSelectionAttribute( attributesToCopy );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );

--- a/src/shiftentercommand.js
+++ b/src/shiftentercommand.js
@@ -8,6 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
+import { getCopyOnEnterAttributes } from './utils';
 
 /**
  * ShiftEnter command. It is used by the {@link module:enter/shiftenter~ShiftEnter ShiftEnter feature} to handle
@@ -81,7 +82,9 @@ function softBreakAction( model, writer, selection ) {
 	const isContainedWithinOneElement = ( startElement == endElement );
 
 	if ( isSelectionEmpty ) {
+		const attributesToCopy = getCopyOnEnterAttributes( model.schema, selection.getAttributes() );
 		insertBreak( writer, range.end );
+		writer.setSelectionAttribute( attributesToCopy );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );
 		model.deleteContent( selection, { leaveUnmerged } );

--- a/src/shiftentercommand.js
+++ b/src/shiftentercommand.js
@@ -84,7 +84,7 @@ function softBreakAction( model, writer, selection ) {
 	if ( isSelectionEmpty ) {
 		const attributesToCopy = getCopyOnEnterAttributes( model.schema, selection.getAttributes() );
 		insertBreak( writer, range.end );
-		// transforms: [ [ key1, value1 ], ... ] => [ key1, ... ]
+
 		writer.removeSelectionAttribute( Array.from( selection.getAttributes() ).map( x => x[ 0 ] ) );
 		writer.setSelectionAttribute( attributesToCopy );
 	} else {

--- a/src/shiftentercommand.js
+++ b/src/shiftentercommand.js
@@ -85,7 +85,7 @@ function softBreakAction( model, writer, selection ) {
 		const attributesToCopy = getCopyOnEnterAttributes( model.schema, selection.getAttributes() );
 		insertBreak( writer, range.end );
 
-		writer.removeSelectionAttribute( Array.from( selection.getAttributeKeys() ) );
+		writer.removeSelectionAttribute( selection.getAttributeKeys() );
 		writer.setSelectionAttribute( attributesToCopy );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );

--- a/src/shiftentercommand.js
+++ b/src/shiftentercommand.js
@@ -84,6 +84,8 @@ function softBreakAction( model, writer, selection ) {
 	if ( isSelectionEmpty ) {
 		const attributesToCopy = getCopyOnEnterAttributes( model.schema, selection.getAttributes() );
 		insertBreak( writer, range.end );
+		// transforms: [ [ key1, value1 ], ... ] => [ key1, ... ]
+		writer.removeSelectionAttribute( Array.from( selection.getAttributes() ).map( x => x[ 0 ] ) );
 		writer.setSelectionAttribute( attributesToCopy );
 	} else {
 		const leaveUnmerged = !( range.start.isAtStart && range.end.isAtEnd );

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,13 +8,13 @@
  */
 
 /**
- * Returns iterator which has filtered attributes read from {@link module:engine/model/selection~Selection#getAttributes selection}.
+ * Returns attributes that should be preserved on the enter key.
  * Filtering is realized based on `copyOnEnter` attribute property. Read more about attribute properties
  * {@link module:engine/model/schema~Schema#setAttributeProperties here}.
  *
  * @param {module:engine/model/schema~Schema} schema
- * @param {Iterable.<*>} allAttributes iterator with attributes of current selection.
- * @returns {Iterable.<*>} filtered attributes which has `copyOnEnter` property.
+ * @param {Iterable.<*>} allAttributes attributes to filter.
+ * @returns {Iterable.<*>}
  */
 export function* getCopyOnEnterAttributes( schema, allAttributes ) {
 	for ( const attribute of allAttributes ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@
 
 /**
  * Returns attributes that should be preserved on the enter key.
+ *
  * Filtering is realized based on `copyOnEnter` attribute property. Read more about attribute properties
  * {@link module:engine/model/schema~Schema#setAttributeProperties here}.
  *

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module enter/utils
+ */
+
+/**
+ * Returns iterator which has filtered attributes read from {@link module:engine/model/selection~Selection#getAttributes selection}.
+ * Filtering is realized based on `copyOnEnter` attribute property. Read more about attribute properties
+ * {@link module:engine/model/schema~Schema#setAttributeProperties here}.
+ *
+ * @param {module:engine/model/schema~Schema} schema
+ * @param {Iterable.<*>} allAttributes iterator with attributes of current selection.
+ * @returns {Iterable.<*>} filtered attributes which has `copyOnEnter` property.
+ */
+export function* getCopyOnEnterAttributes( schema, allAttributes ) {
+	for ( const attribute of allAttributes ) {
+		if ( attribute && schema.getAttributeProperties( attribute[ 0 ] ).copyOnEnter ) {
+			yield attribute;
+		}
+	}
+}

--- a/tests/entercommand.js
+++ b/tests/entercommand.js
@@ -90,7 +90,7 @@ describe( 'EnterCommand', () => {
 
 			describe( 'copyOnEnter', () => {
 				beforeEach( () => {
-					schema.extend( '$text', { allowAttributes: 'foo' } );
+					schema.extend( '$text', { allowAttributes: [ 'foo', 'bar' ] } );
 					schema.setAttributeProperties( 'foo', { copyOnEnter: true } );
 				} );
 

--- a/tests/entercommand.js
+++ b/tests/entercommand.js
@@ -101,7 +101,7 @@ describe( 'EnterCommand', () => {
 				);
 
 				test(
-					'unknown attributes are disabled',
+					'unknown attributes are not copied',
 					'<p><$text bar="true">test[]</$text></p>',
 					'<p><$text bar="true">test</$text></p><p>[]</p>'
 				);

--- a/tests/entercommand.js
+++ b/tests/entercommand.js
@@ -87,6 +87,31 @@ describe( 'EnterCommand', () => {
 				'<p>x</p><p>[]</p><p>y</p>',
 				'<p>x</p><p></p><p>[]</p><p>y</p>'
 			);
+
+			describe( 'copyOnEnter', () => {
+				beforeEach( () => {
+					schema.extend( '$text', { allowAttributes: 'foo' } );
+					schema.setAttributeProperties( 'foo', { copyOnEnter: true } );
+				} );
+
+				test(
+					'allowed attributes are copied',
+					'<p><$text foo="true">test[]</$text></p>',
+					'<p><$text foo="true">test</$text></p><p selection:foo="true"><$text foo="true">[]</$text></p>'
+				);
+
+				test(
+					'unknown attributes are disabled',
+					'<p><$text bar="true">test[]</$text></p>',
+					'<p><$text bar="true">test</$text></p><p>[]</p>'
+				);
+
+				test(
+					'only allowed attributes are copied from mix set',
+					'<p><$text bar="true" foo="true">test[]</$text></p>',
+					'<p><$text bar="true" foo="true">test</$text></p><p selection:foo="true"><$text foo="true">[]</$text></p>'
+				);
+			} );
 		} );
 
 		describe( 'non-collapsed selection', () => {

--- a/tests/shiftentercommand.js
+++ b/tests/shiftentercommand.js
@@ -101,6 +101,31 @@ describe( 'ShiftEnterCommand', () => {
 				'<p>x</p><p>[]foo</p><p>y</p>',
 				'<p>x</p><p><softBreak></softBreak>[]foo</p><p>y</p>'
 			);
+
+			describe( 'copyOnEnter', () => {
+				beforeEach( () => {
+					schema.extend( '$text', { allowAttributes: [ 'foo', 'bar' ] } );
+					schema.setAttributeProperties( 'foo', { copyOnEnter: true } );
+				} );
+
+				test(
+					'allowed attributes are copied',
+					'<p><$text foo="true">test[]</$text></p>',
+					'<p><$text foo="true">test</$text><softBreak></softBreak><$text foo="true">[]</$text></p>'
+				);
+
+				test(
+					'unknown attributes are not copied',
+					'<p><$text bar="true">test[]</$text></p>',
+					'<p><$text bar="true">test</$text><softBreak></softBreak>[]</p>'
+				);
+
+				test(
+					'only allowed attributes are copied from mix set',
+					'<p><$text bar="true" foo="true">test[]</$text></p>',
+					'<p><$text bar="true" foo="true">test</$text><softBreak></softBreak><$text foo="true">[]</$text></p>'
+				);
+			} );
 		} );
 
 		describe( 'non-collapsed selection', () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import { getCopyOnEnterAttributes } from '../src/utils';
+import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
+
+describe( 'utils', () => {
+	describe( 'getCopyOnEnterAttributes()', () => {
+		it( 'filters attributes with copyOnEnter property', () => {
+			return ModelTestEditor.create()
+				.then( editor => {
+					const schema = editor.model.schema;
+
+					schema.register( 'foo', { inheritAllFrom: '$block' } );
+					schema.register( 'bar', { inheritAllFrom: '$block' } );
+					schema.register( 'baz', { inheritAllFrom: '$block' } );
+
+					schema.setAttributeProperties( 'foo', { copyOnEnter: true } );
+					schema.setAttributeProperties( 'baz', { copyOnEnter: true } );
+
+					const allAttributes = ( new Map( [
+						[ 'foo', true ],
+						[ 'bar', true ],
+						[ 'baz', true ]
+					] ) )[ Symbol.iterator ]();
+
+					expect( Array.from( getCopyOnEnterAttributes( schema, allAttributes ) ) ).to.deep.equal(
+						[
+							[ 'foo', true ],
+							[ 'baz', true ]
+						]
+					);
+				} );
+		} );
+	} );
+} );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -13,9 +13,9 @@ describe( 'utils', () => {
 				.then( editor => {
 					const schema = editor.model.schema;
 
-					schema.register( 'foo', { inheritAllFrom: '$block' } );
-					schema.register( 'bar', { inheritAllFrom: '$block' } );
-					schema.register( 'baz', { inheritAllFrom: '$block' } );
+					schema.extend( '$text', {
+						allowAttributes: [ 'foo', 'bar', 'baz' ]
+					} );
 
 					schema.setAttributeProperties( 'foo', { copyOnEnter: true } );
 					schema.setAttributeProperties( 'baz', { copyOnEnter: true } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add support for respecting `copyOnEnter` attribute's parameter. Closes ckeditor/ckeditor5#4562.

---

### Additional information
Dependent PR:
- ~ckeditor/ckeditor5-alignment#41~
- ckeditor/ckeditor5-basic-styles#92
- ckeditor/ckeditor5-font#48
- ckeditor/ckeditor5-engine#1741
